### PR TITLE
[mellanox]: Adapt to new hw-management package

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2100-r0/hw-management
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/hw-management
@@ -1,1 +1,0 @@
-/etc/mlnx/msn2100

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/plugins/eeprom.py
@@ -28,5 +28,5 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
     _TLV_INFO_MAX_LEN = 256
 
     def __init__(self, name, path, cpld_root, ro):
-        self.eeprom_path = "/bsp/eeprom/sys_eeprom"
+        self.eeprom_path = "/bsp/eeprom/vpd_info"
         super(board, self).__init__(self.eeprom_path, 0, '', True)

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/hw-management
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/hw-management
@@ -1,1 +1,0 @@
-/etc/mlnx/msn2410

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/plugins/eeprom.py
@@ -28,5 +28,5 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
     _TLV_INFO_MAX_LEN = 256
 
     def __init__(self, name, path, cpld_root, ro):
-        self.eeprom_path = "/bsp/eeprom/sys_eeprom"
+        self.eeprom_path = "/bsp/eeprom/vpd_info"
         super(board, self).__init__(self.eeprom_path, 0, '', True)

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/hw-management
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/hw-management
@@ -1,1 +1,0 @@
-/etc/mlnx/msn2700

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/plugins/eeprom.py
@@ -28,5 +28,5 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
     _TLV_INFO_MAX_LEN = 256
 
     def __init__(self, name, path, cpld_root, ro):
-        self.eeprom_path = "/bsp/eeprom/sys_eeprom"
+        self.eeprom_path = "/bsp/eeprom/vpd_info"
         super(board, self).__init__(self.eeprom_path, 0, '', True)

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/hw-management
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/hw-management
@@ -1,1 +1,0 @@
-/etc/mlnx/msn2740

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/eeprom.py
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/plugins/eeprom.py
@@ -28,5 +28,5 @@ class board(eeprom_tlvinfo.TlvInfoDecoder):
     _TLV_INFO_MAX_LEN = 256
 
     def __init__(self, name, path, cpld_root, ro):
-        self.eeprom_path = "/bsp/eeprom/sys_eeprom"
+        self.eeprom_path = "/bsp/eeprom/vpd_info"
         super(board, self).__init__(self.eeprom_path, 0, '', True)

--- a/files/build_templates/swss.service.j2
+++ b/files/build_templates/swss.service.j2
@@ -30,7 +30,7 @@ ExecStartPre=/usr/bin/mst start
 ExecStartPre=/usr/bin/mlnx-fw-upgrade.sh
 ExecStartPre=/etc/init.d/sxdkernel start
 ExecStartPre=/sbin/modprobe i2c-dev
-ExecStartPre=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -v platform)/hw-management start"
+ExecStartPre=/etc/mlnx/mlnx-hw-management start
 {% elif sonic_asic_platform == 'cavium' %}
 ExecStartPre=/etc/init.d/xpnet.sh start
 {% endif %}
@@ -43,7 +43,7 @@ ExecStop=/usr/bin/{{docker_container_name}}.sh stop
 ExecStopPost=/usr/bin/syncd.sh stop
 
 {% if sonic_asic_platform == 'mellanox' %}
-ExecStopPost=/bin/bash -c "/usr/share/sonic/device/$(sonic-cfggen -v platform)/hw-management stop"
+ExecStopPost=/etc/mlnx/mlnx-hw-management stop
 ExecStopPost=/etc/init.d/sxdkernel stop
 ExecStopPost=/usr/bin/mst stop
 {% elif sonic_asic_platform == 'cavium' %}


### PR DESCRIPTION
Use single start script for all platforms and remove symbolic links
Change path to system eeprom

Signed-off-by: marian-pritsak <marianp@mellanox.com>