### PR TITLE
mgmt vrf related change for Buster

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -74,10 +74,6 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }} metric 201
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    up cgcreate -g l3mdev:mgmt
-    up cgset -r l3mdev.master-device=mgmt mgmt
-{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     up ip rule add to {{ route }} table {{ vrf_table }}
 {% endfor %}
@@ -85,9 +81,6 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    down cgdelete -g l3mdev:mgmt
-{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     pre-down ip rule delete to {{ route }} table {{ vrf_table }}
 {% endfor %}
@@ -98,9 +91,6 @@ iface eth0 inet dhcp
     metric 202
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
     vrf mgmt
-    up cgcreate -g l3mdev:mgmt
-    up cgset -r l3mdev.master-device=mgmt mgmt
-    down cgdelete -g l3mdev:mgmt
 {% endif %}
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1


### PR DESCRIPTION
**- What I did**
Partial code change for mgmt vrf related buster change.
This pull request removes  cgcreate, cgset, cgdelete for l3mdev:mgmt in interfaces.j2, which are not applicable for linux 4.19.


**- How I did it**
In interfaces.j2, remove cgcreate, cgset, cgdelete for l3mdev:mgmt

**- How to verify it**
Test from click
- config vrf add mgmt
   check ip vrf show from kernel
   ping remote ip, traceroute, scp with "ip vrf exec mgmt"
 - config vrf del mgmt
   check ip vrf show from kernel
   ping remote ip, traceroute, scp


for mgmt vrf add
//////////////////////
root@sonic:~# ip vrf show
Name              Table
-----------------------
No VRF has been configured
root@sonic:~#
root@sonic:~#
root@sonic:~#
root@sonic:~# config vrf add mgmt


root@sonic:~#
root@sonic:~#
root@sonic:~# ip vrf show
Name              Table
-----------------------
mgmt              5000
root@sonic:~#
root@sonic:~#
root@sonic:~# ip vrf exec mgmt ping 10.14.8.140
PING 10.14.8.140 (10.14.8.140) 56(84) bytes of data.
64 bytes from 10.14.8.140: icmp_seq=1 ttl=61 time=2.07 ms
64 bytes from 10.14.8.140: icmp_seq=2 ttl=61 time=1.69 ms
^C
--- 10.14.8.140 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 2ms
rtt min/avg/max/mdev = 1.685/1.875/2.065/0.190 ms
root@sonic:~#


for mgmt vrf delete
//////////////////////

root@sonic:~# ip vrf show
Name              Table
-----------------------
mgmt              5000
root@sonic:~#
root@sonic:~#
root@sonic:~#
root@sonic:~# config vrf del mgmt
root@sonic:~#
root@sonic:~#
root@sonic:~#
root@sonic:~# ip vrf show
Name              Table
-----------------------
No VRF has been configured
root@sonic:~#
root@sonic:~#
root@sonic:~#
root@sonic:~# ping 10.14.8.140
PING 10.14.8.140 (10.14.8.140) 56(84) bytes of data.
64 bytes from 10.14.8.140: icmp_seq=1 ttl=61 time=1.95 ms
64 bytes from 10.14.8.140: icmp_seq=2 ttl=61 time=1.66 ms
64 bytes from 10.14.8.140: icmp_seq=3 ttl=61 time=1.66 ms
64 bytes from 10.14.8.140: icmp_seq=4 ttl=61 time=1.69 ms
^C
--- 10.14.8.140 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 7ms
rtt min/avg/max/mdev = 1.661/1.742/1.954/0.122 ms
root@sonic:~#



**- Description for the changelog**

modify interfaces.j2 for mgmt vrf handling in Buster