### PR TITLE
[ntp] add ntp support in buster with mgmt vrf

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -446,6 +446,10 @@ if [ -f files/image_config/ntp/ntp ]; then
     sudo cp ./files/image_config/ntp/ntp $FILESYSTEM_ROOT/etc/init.d/
 fi
 
+if [ -f files/image_config/ntp/ntp-systemd-wrapper ]; then
+    sudo cp ./files/image_config/ntp/ntp-systemd-wrapper $FILESYSTEM_ROOT/usr/lib/ntp/
+fi
+
 ## Version file
 sudo mkdir -p $FILESYSTEM_ROOT/etc/sonic
 sudo tee $FILESYSTEM_ROOT/etc/sonic/sonic_version.yml > /dev/null <<EOF

--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -74,10 +74,6 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }} metric 201
     up ip {{ '-4' if prefix | ipv4 else '-6' }} route add {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     up ip {{ '-4' if prefix | ipv4 else '-6' }} rule add from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    up cgcreate -g l3mdev:mgmt
-    up cgset -r l3mdev.master-device=mgmt mgmt
-{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     up ip rule add to {{ route }} table {{ vrf_table }}
 {% endfor %}
@@ -85,9 +81,6 @@ iface eth0 {{ 'inet' if prefix | ipv4 else 'inet6' }} static
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete default via {{ MGMT_INTERFACE[(name, prefix)]['gwaddr'] }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} route delete {{ prefix | network }}/{{ prefix | prefixlen }} dev eth0 table {{ vrf_table }}
     pre-down ip {{ '-4' if prefix | ipv4 else '-6' }} rule delete from {{ prefix | ip }}/{{ '32' if prefix | ipv4 else '128' }} table {{ vrf_table }}
-{% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
-    down cgdelete -g l3mdev:mgmt
-{% endif %}
 {% for route in MGMT_INTERFACE[(name, prefix)]['forced_mgmt_routes'] %}
     pre-down ip rule delete to {{ route }} table {{ vrf_table }}
 {% endfor %}
@@ -98,9 +91,6 @@ iface eth0 inet dhcp
     metric 202
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
     vrf mgmt
-    up cgcreate -g l3mdev:mgmt
-    up cgset -r l3mdev.master-device=mgmt mgmt
-    down cgdelete -g l3mdev:mgmt
 {% endif %}
 iface eth0 inet6 dhcp
     up sysctl net.ipv6.conf.eth0.accept_ra=1

--- a/files/image_config/ntp/ntp-systemd-wrapper
+++ b/files/image_config/ntp/ntp-systemd-wrapper
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This file was originally created automatically as part of default NTP application installation from debian package.
+# This is now manually modified for supporting NTP in management VRF.
+# When management VRF is enabled, the NTP application should be started using "ip vrf exec mgmt".
+# Check has been added to verify the management VRF enabled status and use "ip vrf exec mgmt"  when it is enabled.
+# This file will be copied to /usr/lib/ntp/ntp-systemd-wrapper file that gets created during build process.
+
+DAEMON=/usr/sbin/ntpd
+PIDFILE=/var/run/ntpd.pid
+
+if [ -r /etc/default/ntp ]; then
+        . /etc/default/ntp
+fi
+
+if [ -e /run/ntp.conf.dhcp ]; then
+        NTPD_OPTS="$NTPD_OPTS -c /run/ntp.conf.dhcp"
+fi
+
+LOCKFILE=/run/lock/ntpdate
+
+RUNASUSER=ntp
+UGID=$(getent passwd $RUNASUSER | cut -f 3,4 -d:) || true
+if test "$(uname -s)" = "Linux"; then
+        NTPD_OPTS="$NTPD_OPTS -u $UGID"
+fi
+
+(
+        flock -w 180 9
+        vrfEnabled=$(/usr/local/bin/sonic-cfggen -d -v 'MGMT_VRF_CONFIG["vrf_global"]["mgmtVrfEnabled"]' 2> /dev/null)
+        if [ "$vrfEnabled" = "true" ]
+        then
+                ip vrf exec mgmt start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- -p $PIDFILE $NTPD_OPTS
+        else
+                start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE --startas $DAEMON -- -p $PIDFILE $NTPD_OPTS
+        fi
+) 9>$LOCKFILE
+


### PR DESCRIPTION
**- What I did**
change in Buster dev for NTP with mgmt vrf

**- How I did it**
- create a file in files/image_config/ntp/ntp-systemd-wrapper to add mgmt vrf related start cmd for ntp service. So that the default /usr/lib/ntp/ntp-systemd-wrapper can be overriden during build time.
- modify build_debian.sh to cp files/image_config/ntp/ntp-systemd-wrapper to /usr/lib/ntp/ntp-systemd-wrapper during build time.

**- How to verify it**

```
- config ntp add xx.xx.xx.xx
- check ntpstat, ntpq -pn
- config mgmt vrf
- check "ip vrf exec mgmt ntpstat" , ip vrf exec mgmt ntpq -pn"
- service ntp start
- service ntp stop
- service ntp status

root@sonic:~# show mgmt-vrf

ManagementVRF : Disabled


root@sonic:~# config ntp add 10.11.0.1
NTP server 10.11.0.1 added to configuration
Restarting ntp-config service...
root@sonic:~#


root@sonic:~# service ntp status
● ntp.service - Network Time Service
   Loaded: loaded (/lib/systemd/system/ntp.service; enabled; vendor preset: enab
   Active: active (running) since Wed 2020-03-25 04:00:42 UTC; 19s ago
     Docs: man:ntpd(8)
  Process: 15898 ExecStart=/usr/lib/ntp/ntp-systemd-wrapper (code=exited, status
 Main PID: 15908 (ntpd)
    Tasks: 2 (limit: 4915)
   Memory: 1.8M
   CGroup: /system.slice/ntp.service
           └─15908 /usr/sbin/ntpd -p /var/run/ntpd.pid -x -u 105:110


oot@sonic:~# ntpstat
synchronised to NTP server (10.11.0.1) at stratum 4
   time correct to within 1940 ms
   polling server every 64 s
root@sonic:~#
root@sonic:~#
root@sonic:~# ntpq -pn
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*10.11.0.1       10.14.2.1        3 u   34   64    1    0.241  -1625.8   0.231
root@sonic:~#


root@sonic:~# config vrf add mgmt
root@sonic:~# show mgmt-vrf

ManagementVRF : Enabled

Management VRF interfaces in Linux:
40: mgmt: <NOARP,MASTER,UP,LOWER_UP> mtu 65536 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether f6:a6:52:de:0c:46 brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 1500
    vrf table 5000 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq master mgmt state UP mode DEFAULT group default qlen 1000
    link/ether 3c:2c:30:1f:9f:80 brd ff:ff:ff:ff:ff:ff
41: lo-m: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue master mgmt state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether e2:bc:53:eb:a8:57 brd ff:ff:ff:ff:ff:ff


root@sonic:~# ip vrf exec mgmt ntpstat
synchronised to NTP server (10.11.0.1) at stratum 4
   time correct to within 1755 ms
   polling server every 64 s
root@sonic:~#
root@sonic:~#
root@sonic:~# ip vrf exec mgmt ntpq -pn
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*10.11.0.1       10.14.2.1        3 u   50   64    3    0.210  -1563.0  25.494


root@sonic:~# service ntp status
● ntp.service - Network Time Service
   Loaded: loaded (/lib/systemd/system/ntp.service; enabled; vendor preset: enab
   Active: active (running) since Wed 2020-03-25 04:02:21 UTC; 2min 32s ago
     Docs: man:ntpd(8)
  Process: 16104 ExecStart=/usr/lib/ntp/ntp-systemd-wrapper (code=exited, status
    Tasks: 2 (limit: 4915)
   Memory: 2.0M
   CGroup: /system.slice/ntp.service
           └─vrf
             └─mgmt
               └─16114 /usr/sbin/ntpd -p /var/run/ntpd.pid -x -u 105:110


root@sonic:~# service ntp restart
root@sonic:~#
root@sonic:~#
root@sonic:~#
root@sonic:~# ip vrf exec mgmt ntpstat
synchronised to NTP server (10.11.0.1) at stratum 4
   time correct to within 1817 ms
   polling server every 64 s
root@sonic:~#
root@sonic:~#
root@sonic:~# ip vrf exec mgmt ntpq -pn
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*10.11.0.1       10.14.2.1        3 u   10   64    1    0.426  -1500.2   6.994
root@sonic:~#
root@sonic:~#
root@sonic:~# service ntp status
● ntp.service - Network Time Service
   Loaded: loaded (/lib/systemd/system/ntp.service; enabled; vendor preset: enab
   Active: active (running) since Wed 2020-03-25 04:05:17 UTC; 35s ago
     Docs: man:ntpd(8)
  Process: 16208 ExecStart=/usr/lib/ntp/ntp-systemd-wrapper (code=exited, status
    Tasks: 2 (limit: 4915)
   Memory: 1.8M
   CGroup: /system.slice/ntp.service
           └─vrf
             └─mgmt
               └─16219 /usr/sbin/ntpd -p /var/run/ntpd.pid -x -u 105:110


```